### PR TITLE
Tests

### DIFF
--- a/PoseidonSharp.sln
+++ b/PoseidonSharp.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31410.357
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoseidonSharp", "PoseidonSharp\PoseidonSharp.csproj", "{626151F3-CCA0-430F-B32D-3EBB885BE341}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PoseidonSharp", "PoseidonSharp\PoseidonSharp.csproj", "{626151F3-CCA0-430F-B32D-3EBB885BE341}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoseidonConsole", "PoseidonConsole\PoseidonConsole.csproj", "{3EA23D88-2EFA-42B8-9939-4C72F2371889}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PoseidonConsole", "PoseidonConsole\PoseidonConsole.csproj", "{3EA23D88-2EFA-42B8-9939-4C72F2371889}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoseidonTests", "PoseidonTests\PoseidonTests.csproj", "{0F5334CD-544E-461A-9DB0-C6CC6EA1FD10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{3EA23D88-2EFA-42B8-9939-4C72F2371889}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EA23D88-2EFA-42B8-9939-4C72F2371889}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EA23D88-2EFA-42B8-9939-4C72F2371889}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F5334CD-544E-461A-9DB0-C6CC6EA1FD10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F5334CD-544E-461A-9DB0-C6CC6EA1FD10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F5334CD-544E-461A-9DB0-C6CC6EA1FD10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F5334CD-544E-461A-9DB0-C6CC6EA1FD10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PoseidonSharp/Eddsa.cs
+++ b/PoseidonSharp/Eddsa.cs
@@ -95,7 +95,17 @@ namespace PoseidonSharp
         {
             var secretBytes = CalculateNumberOfBytes(k);
             var mBytes = CalculateNumberOfBytes(args);
-            var combinedBytes = CombineBytes(secretBytes, mBytes); 
+            byte[] positiveBytes = null;
+            if (mBytes.Length < 32) //pad out bits
+            {
+                positiveBytes = new byte[mBytes.Length + 1];
+                Array.Copy(mBytes, positiveBytes, mBytes.Length);
+            }
+            else
+            {
+                positiveBytes = mBytes;
+            }
+            var combinedBytes = CombineBytes(secretBytes, positiveBytes);
             byte[] sha512Hash;
             SHA512 sha512 = new SHA512Managed();
             sha512Hash = sha512.ComputeHash(combinedBytes);

--- a/PoseidonSharp/Eddsa.cs
+++ b/PoseidonSharp/Eddsa.cs
@@ -25,7 +25,7 @@ namespace PoseidonSharp
             BigInteger privateKeyBigInteger = BigInteger.Parse(_privateKey.Substring(2, _privateKey.Length - 2), NumberStyles.AllowHexSpecifier);
             if(privateKeyBigInteger.Sign == -1)
             {
-                string bigIntHex = "0" + privateKeyBigInteger.ToString("x2");
+                string bigIntHex = "0" + _privateKey.Substring(2, _privateKey.Length - 2);
                 privateKeyBigInteger = BigInteger.Parse(bigIntHex, NumberStyles.AllowHexSpecifier);
             }
             PrivateKey = privateKeyBigInteger;
@@ -83,8 +83,6 @@ namespace PoseidonSharp
             string finalMessage = "0x" + rX + rY + rS;
             return finalMessage;
         }
-
-
 
         private BigInteger HashPublic((BigInteger x, BigInteger y) r, (BigInteger x, BigInteger y) a, BigInteger m)
         {

--- a/PoseidonTests/HashingTests.cs
+++ b/PoseidonTests/HashingTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PoseidonSharp;
+using System.Numerics;
+
+namespace PoseidonTests
+{
+    [TestClass]
+    public class HashingTests
+    {
+        [TestMethod]
+        public void PoseidonHashTest1()
+        {
+            int MAX_INPUT = 13;
+            Poseidon poseidon = new Poseidon(MAX_INPUT + 1, 6, 53, "poseidon", 5, _securityTarget: 128);
+            BigInteger[] inputs = { BigInteger.Parse("1")};
+            BigInteger poseidonHash = poseidon.CalculatePoseidonHash(inputs);
+            Assert.AreEqual(BigInteger.Parse("14018714854885098128064817341184136022863799846023165041562300563859625887667"), poseidonHash);
+        }
+
+        [TestMethod]
+        public void PoseidonHashTest2()
+        {
+            int MAX_INPUT = 13;
+            Poseidon poseidon = new Poseidon(MAX_INPUT + 1, 6, 53, "poseidon", 5, _securityTarget: 128);
+            BigInteger[] inputs = {BigInteger.Parse("14018714854885098128064817341184136022863799846023165041562300563859625887667")};
+            BigInteger poseidonHash = poseidon.CalculatePoseidonHash(inputs);
+            Assert.AreEqual(BigInteger.Parse("14909270658865229119931025210898882982405891235271722645312816457103330375266"), poseidonHash);
+        }
+
+        [TestMethod]
+        public void PoseidonHashTest3()
+        {
+            int MAX_INPUT = 13;
+            Poseidon poseidon = new Poseidon(MAX_INPUT + 1, 6, 53, "poseidon", 5, _securityTarget: 128);
+            BigInteger[] inputs = { 
+                BigInteger.Parse("1401871485488509812806481"),
+                BigInteger.Parse("900000000"),
+                BigInteger.Parse("2000000000"),
+                BigInteger.Parse("300000000"),
+                BigInteger.Parse("500000000"),
+                BigInteger.Parse("1000000000000")
+            };
+            BigInteger poseidonHash = poseidon.CalculatePoseidonHash(inputs);
+            Assert.AreEqual(BigInteger.Parse("12787485214590893264756354332223190110048608099767720695619651876987364797309"), poseidonHash);
+        }
+
+        [TestMethod]
+        public void SHA256HelperHashTest1()
+        {
+            BigInteger sha256HashNumber = SHA256Helper.CalculateSHA256HashNumber("GET&https%3A%2F%2Fuat3.loopring.io%2Fapi%2Fv3%2FapiKey&accountId%3D11087");
+            Assert.AreEqual(BigInteger.Parse("19400808358061590369279192378878962429412529891699423035130831734199348072763"), sha256HashNumber);
+        }
+    }
+}

--- a/PoseidonTests/PoseidonTests.csproj
+++ b/PoseidonTests/PoseidonTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PoseidonSharp\PoseidonSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PoseidonTests/SigningTests.cs
+++ b/PoseidonTests/SigningTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PoseidonSharp;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace PoseidonTests
+{
+    [TestClass]
+    public class SigningTests
+    {
+        private static string PrivateKey = "0xff2f95f7f25dd17d160595603d49f9bd0bae765403d5d171fe1db2a3218c91"; // This private key has been unpaired from the real account
+        private static string PrivateKey2 = "0x19bd8d52d552d2f112b478686f18577b8088e5b1860c3523c53f943304951c3"; //This private key has been unpaired from the real account
+        [TestMethod]
+        public void PoseidonEddsaTest1()
+        {
+            int MAX_INPUT = 13;
+            Poseidon poseidon = new Poseidon(MAX_INPUT + 1, 6, 53, "poseidon", 5, _securityTarget: 128);
+            BigInteger[] inputs = { BigInteger.Parse("15262223708097584402615283257936266522564860189809682357548133077263290491192") };
+            BigInteger poseidonHash = poseidon.CalculatePoseidonHash(inputs);
+            Assert.AreEqual(BigInteger.Parse("20006412648033755550733273460666169594962583918414636802156211610404306681114"), poseidonHash);
+            Eddsa eddsa = new Eddsa(poseidonHash, PrivateKey);
+            string signedMessage = eddsa.Sign();
+            Assert.AreEqual("0x001306880e5a09076cba1e29a36fc4802be32338e0e6a922094ac2417662e14320a95f7f56d3e6241b6191344f1f9ee69dbc60ea244a06ded7c7b22c55c0af402fd957e3e2bd506741319064ec0e76ab44db7c0da08e8821137f09a6d30f0d68", signedMessage);
+        }
+
+        [TestMethod]
+        public void PoseidonEddsaTest2()
+        {
+            int MAX_INPUT = 13;
+            Poseidon poseidon = new Poseidon(MAX_INPUT + 1, 6, 53, "poseidon", 5, _securityTarget: 128);
+            BigInteger[] inputs = { BigInteger.Parse("95262223708097584402615283257936266522564860189809682357548133077263290491192") };
+            BigInteger poseidonHash = poseidon.CalculatePoseidonHash(inputs);
+            Assert.AreEqual(BigInteger.Parse("133231497719586149593023275410024405046152548029140595410125539923302973012"), poseidonHash);
+            Eddsa eddsa = new Eddsa(poseidonHash, PrivateKey2);
+            string signedMessage = eddsa.Sign();
+            Assert.AreEqual("0x0d24a82d5d6a0548bcae75ca35d42220d314a9a7534c033282e2406ebb76464808ec18c987f64b817cee1eabb5b66df973daf1f240b0fb76de439896eb1d097601f3660c07cbe3fe3b48feab92e5962aa4fc6de16b1236eb7d98eb75bc5b66c7", signedMessage);
+        }
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library's reference implementation was originally in python and taken from 
 
 This is probably not production ready...so use at your own risk!
 
-The included PoseidonConsole project contains some demo code on how to use the library.
+The included PoseidonConsole project contains some demo code on how to use the library. PoseidonTests contains the unit tests for MSTest.
 
 ## Important
 


### PR DESCRIPTION
@taranasus I've add MSTests to the project and found a bug with some private keys giving 31 bytes instead of 32 bytes in the Hashing the secret function in Eddsa. Can you test with your api to see make sure the changes don't break it please?